### PR TITLE
Fix plugin execution when disabled

### DIFF
--- a/lib/discourse_h_captcha/create_users_controller_patch.rb
+++ b/lib/discourse_h_captcha/create_users_controller_patch.rb
@@ -8,6 +8,8 @@ module DiscourseHCaptcha
     included { before_action :check_h_captcha, only: [:create] }
 
     def check_h_captcha
+      return unless SiteSetting.discourse_hCaptcha_enabled
+
       h_captcha_token = fetch_h_captcha_token
       raise Discourse::InvalidAccess.new if h_captcha_token.blank?
 

--- a/spec/lib/discourse_h_captcha/create_users_controller_patch_spec.rb
+++ b/spec/lib/discourse_h_captcha/create_users_controller_patch_spec.rb
@@ -61,9 +61,7 @@ RSpec.describe "Users", type: :request do
     end
 
     context "when h_captcha is disabled" do
-      before do 
-        SiteSetting.discourse_hCaptcha_enabled = false
-      end
+      before { SiteSetting.discourse_hCaptcha_enabled = false }
 
       it "succeeds in registration" do
         post "/u.json", params: user_params

--- a/spec/lib/discourse_h_captcha/create_users_controller_patch_spec.rb
+++ b/spec/lib/discourse_h_captcha/create_users_controller_patch_spec.rb
@@ -60,6 +60,17 @@ RSpec.describe "Users", type: :request do
       end
     end
 
+    context "when h_captcha is disabled" do
+      before do 
+        SiteSetting.discourse_hCaptcha_enabled = false
+      end
+
+      it "succeeds in registration" do
+        post "/u.json", params: user_params
+        expect(JSON.parse(response.body)["success"]).to be(true)
+      end
+    end
+
     private
 
     def honeypot_magic(params)


### PR DESCRIPTION
**Problem** 
The `check_h_captcha` method is still getting executed even when the plugin is disabled.

**Solution**
Use a flag to avoid executing this method when the plugin is not enabled