### PR TITLE
added link to hcaptcha.com to site settings

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -9,8 +9,8 @@ en:
         discourse_hcaptcha: "hCaptcha Plugin"
         
   site_settings:
-    discourse_hcaptcha_enabled: "Enable the hCaptcha Plugin"
-    hcaptcha_site_key: "hCaptcha Site Key"
-    hcaptcha_secret_key: "hCaptcha Secret Key"
+    discourse_hcaptcha_enabled: "Enable the hCaptcha Plugin. Requires <a target='blank' href='https://hcaptcha.com'>hcaptcha.com</a> account."
+    hcaptcha_site_key: "hCaptcha Site Key from your <a target='blank' href='https://hcaptcha.com'>hcaptcha.com</a> account"
+    hcaptcha_secret_key: "hCaptcha Secret Key from your <a target='blank' href='https://hcaptcha.com'>hcaptcha.com</a> account"
 
   h_captcha_verification_failed: "hCaptcha verification failed"


### PR DESCRIPTION
added guidance to prevent site owners from accidentally enabling this plugin without also providing hCaptcha keys and making it impossible to signup, as discussed in https://meta.discourse.org/t/discourse-hcaptcha/291383/25?u=tobiaseigen